### PR TITLE
Add comprehensive Zsh configuration with Fish parity

### DIFF
--- a/config/.config/starship.toml
+++ b/config/.config/starship.toml
@@ -15,7 +15,7 @@ error_symbol = '[](bold #F7768E)'
 fish_indicator = ""
 unknown_indicator = "?"
 style = "bold fg:white"
-disabled = false
+disabled = true
 ## end character ##
 
 ## start prompt ##

--- a/config/.config/topgrade.toml
+++ b/config/.config/topgrade.toml
@@ -31,6 +31,7 @@ skip_notify = true
 # Custom commands
 [commands]
 "Fisher Plugins" = "fisher update &>/dev/null; and echo 'Fisher Update Complete'"
+"Antidote Plugins" = "antidote update"
 "LazyVim Plugins" = "nvim --headless -c 'Lazy! sync' +qa"
 "Treesitter Parsers" = "nvim --headless -c 'sleep 100m' -c 'TSUpdate' -c 'qa'"
 "Claude Code" = "claude update"

--- a/dots/.zshenv
+++ b/dots/.zshenv
@@ -1,3 +1,0 @@
-# bun
-export BUN_INSTALL="$HOME/.bun"
-export PATH="$BUN_INSTALL/bin:$PATH"

--- a/dots/.zshrc
+++ b/dots/.zshrc
@@ -1,6 +1,0 @@
-
-. "$HOME/.local/share/../bin/env"
-
-
-# Atlas
-alias atlas='bun /Users/ed/.claude/skills/PAI/Tools/pai.ts'

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 
 set shell := ["bash", "-cu"]
 
-stow_packages := "dots git fish config neoed local wezterm"
+stow_packages := "dots git fish zsh config neoed local wezterm"
 
 yellow := '\033[33m'
 green := '\033[32m'
@@ -60,6 +60,9 @@ update:
     @for pkg in {{stow_packages}}; do \
         if [ "$pkg" = "fish" ]; then \
             rm -f ~/.config/fish/conf.d/brew.fish ~/.config/fish/conf.d/fish-ssh-agent.fish; \
+        fi; \
+        if [ "$pkg" = "zsh" ]; then \
+            rm -f ~/.config/zsh/.zcompdump*; \
         fi; \
         stow --restow $pkg; \
     done

--- a/justfile
+++ b/justfile
@@ -66,7 +66,7 @@ update:
         fi; \
         stow --restow $pkg; \
     done
-    @printf "{{green}}Dotfiles updated successfully{{clr}} - run {{yellow}}reload{{clr}} to apply changes to Fish\n"
+    @printf "{{green}}Dotfiles updated successfully{{clr}} - run {{yellow}}reload{{clr}} to apply changes to your shell\n"
 
 # Remove all dotfile symlinks
 delete:

--- a/local/.local/bin/chshell
+++ b/local/.local/bin/chshell
@@ -1,0 +1,37 @@
+#!/bin/sh
+# chshell — quickly switch login shell between fish, zsh, and bash
+set -e
+
+usage() {
+  printf "Usage: chshell <fish|zsh|bash>\n"
+  printf "Switch your default login shell.\n\n"
+  printf "Shells:\n"
+  printf "  fish    %s\n" "$(command -v fish 2>/dev/null || echo 'not installed')"
+  printf "  zsh     %s\n" "$(command -v zsh 2>/dev/null || echo 'not installed')"
+  printf "  bash    %s\n" "$(command -v bash 2>/dev/null || echo 'not installed')"
+  printf "\nCurrent: %s\n" "$SHELL"
+  exit 1
+}
+
+[ -z "$1" ] && usage
+
+case "$1" in
+  fish) shell_path="$(command -v fish 2>/dev/null)" ;;
+  zsh)  shell_path="$(command -v zsh 2>/dev/null)" ;;
+  bash) shell_path="$(command -v bash 2>/dev/null)" ;;
+  *)    printf "Unknown shell: %s\n" "$1"; usage ;;
+esac
+
+if [ -z "$shell_path" ]; then
+  printf "Error: %s is not installed\n" "$1"
+  exit 1
+fi
+
+if [ "$SHELL" = "$shell_path" ]; then
+  printf "Already using %s (%s)\n" "$1" "$shell_path"
+  exit 0
+fi
+
+printf "Switching to %s (%s)...\n" "$1" "$shell_path"
+chsh -s "$shell_path"
+printf "Done. New terminals will use %s.\n" "$1"

--- a/packages/Brewfile
+++ b/packages/Brewfile
@@ -40,6 +40,7 @@ brew 'starship'                             # Cross-shell prompt - Rust
 brew 'jandedobbeleer/oh-my-posh/oh-my-posh' # Cross-shell prompt - Go
 
 # zsh plugins
+brew 'antidote'                            # Zsh plugin manager (lightweight, no Oh My Zsh)
 brew 'zsh-syntax-highlighting'             # Syntax highlighting for zsh
 brew 'zsh-autopair'                        # Auto-pairing for zsh
 brew 'olets/tap/zsh-abbr'                  # Abbreviations for zsh

--- a/wezterm/.config/wezterm/configuration.lua
+++ b/wezterm/.config/wezterm/configuration.lua
@@ -9,8 +9,7 @@ local function setup(theme, keymaps)
     config = wezterm.config_builder()
   end
 
-  -- Shell
-  config.default_prog = { "/opt/homebrew/bin/fish", "-l" }
+  -- Shell: no default_prog — WezTerm uses login shell from OS (respects chsh)
   config.term = "xterm-256color"
 
   -- Input

--- a/zsh/.config/zsh/.zsh_plugins.txt
+++ b/zsh/.config/zsh/.zsh_plugins.txt
@@ -1,0 +1,18 @@
+# Fish-equivalent plugins for Zsh (managed by Antidote)
+# Inline suggestions from history (Fish's killer feature)
+zsh-users/zsh-autosuggestions
+
+# Real-time syntax coloring (better perf than zsh-syntax-highlighting)
+zdharma-continuum/fast-syntax-highlighting
+
+# Fish-style abbreviations with inline expansion
+olets/zsh-abbr
+
+# Fish-style up/down arrow history search
+zsh-users/zsh-history-substring-search
+
+# Auto-close brackets, quotes, parens (≈ laughedelic/pisces)
+hlissner/zsh-autopair
+
+# Additional completion definitions
+zsh-users/zsh-completions kind:fpath

--- a/zsh/.config/zsh/.zshenv
+++ b/zsh/.config/zsh/.zshenv
@@ -1,0 +1,87 @@
+# Non-interactive environment — loaded for ALL Zsh instances (scripts, cron, etc.)
+# Paths, exports, and variables needed before .zshrc loads.
+
+# --- PATH deduplication (like fish_add_path) ---
+typeset -U path
+
+# --- Homebrew (Apple Silicon first, Intel fallback) ---
+if [[ -x /opt/homebrew/bin/brew ]]; then
+  export HOMEBREW_PREFIX=/opt/homebrew
+  export HOMEBREW_CELLAR=/opt/homebrew/Cellar
+  export HOMEBREW_REPOSITORY=/opt/homebrew
+  path=(/opt/homebrew/bin /opt/homebrew/sbin $path)
+  export MANPATH="/opt/homebrew/share/man${MANPATH:+:$MANPATH}"
+  export INFOPATH="/opt/homebrew/share/info${INFOPATH:+:$INFOPATH}"
+elif [[ -x /usr/local/bin/brew ]]; then
+  export HOMEBREW_PREFIX=/usr/local
+  export HOMEBREW_CELLAR=/usr/local/Cellar
+  export HOMEBREW_REPOSITORY=/usr/local/Homebrew
+  path=(/usr/local/bin /usr/local/sbin $path)
+  export MANPATH="/usr/local/share/man${MANPATH:+:$MANPATH}"
+  export INFOPATH="/usr/local/share/info${INFOPATH:+:$INFOPATH}"
+fi
+
+# --- XDG Base Directory ---
+export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_DESKTOP_DIR="$HOME/Desktop"
+export XDG_DOWNLOAD_DIR="$HOME/Downloads"
+export XDG_DOCUMENTS_DIR="$HOME/Documents"
+export XDG_MUSIC_DIR="$HOME/Music"
+export XDG_PICTURES_DIR="$HOME/Pictures"
+export XDG_VIDEOS_DIR="$HOME/Videos"
+
+# --- Core tools ---
+export EDITOR=nvim
+export TERMINAL=wezterm
+export LC_ALL=en_US.UTF-8
+export MANPAGER="nvim +Man!"
+export EZA_CONFIG_DIR="$HOME/.config/eza"
+export EZA_COLORS="gm=33;1"
+
+# --- Go ---
+export GOPATH="$HOME/.go"
+path=($GOPATH/bin $path)
+
+# --- Node / PNPM ---
+export PNPM_HOME="$HOME/Library/pnpm"
+path=($PNPM_HOME $path)
+
+# --- Bun ---
+export BUN_INSTALL="$HOME/.bun"
+path=($BUN_INSTALL/bin $path)
+
+# --- Python (pyenv) ---
+export PYENV_ROOT="$HOME/.pyenv"
+path=($PYENV_ROOT/bin $path)
+
+# --- Rust (cargo) ---
+path=($HOME/.cargo/bin $path)
+
+# --- Ruby gems ---
+path=($HOME/.gem/ruby/3.0.2/bin $path)
+
+# --- PHP ---
+path=($HOME/.composer/vendor/bin $path)
+
+# --- Other tools ---
+path=(
+  $HOME/.local/bin
+  $HOMEBREW_PREFIX/opt/openssl@1.1/bin
+  $HOMEBREW_PREFIX/opt/make/libexec/gnubin
+  /Applications/Warp.app/Contents/MacOS
+  $HOME/.antigravity/antigravity/bin
+  $path
+)
+
+# --- FZF ---
+export FZF_DEFAULT_COMMAND="fd --type f"
+export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+
+# --- Projects ---
+export PROJECTS_DIR="$HOME/Developer"
+
+# --- Netlify credential helper ---
+[[ -f "$HOME/Library/Preferences/netlify/helper/path.zsh.inc" ]] \
+  && source "$HOME/Library/Preferences/netlify/helper/path.zsh.inc"

--- a/zsh/.config/zsh/.zshrc
+++ b/zsh/.config/zsh/.zshrc
@@ -3,6 +3,9 @@
 
 [[ -o interactive ]] || return
 
+# --- Mise (runtime manager) ---
+[[ -f "$HOME/.local/bin/env" ]] && . "$HOME/.local/bin/env"
+
 # --- Antidote plugin manager ---
 # Try ZDOTDIR-local install first, fall back to Homebrew
 if [[ -f "${ZDOTDIR:-$HOME}/.antidote/antidote.zsh" ]]; then
@@ -78,6 +81,9 @@ case "$ZSH_PROMPT" in
   starship)   eval "$(starship init zsh)" ;;
   oh-my-posh) eval "$(oh-my-posh init zsh --config ~/.config/starship-ish.omp.json)" ;;
 esac
+
+# --- Atlas (PAI) ---
+alias atlas='bun /Users/ed/.claude/skills/PAI/Tools/pai.ts'
 
 # --- Nvim shell integration ---
 if [[ "$TERM_PROGRAM" == "nvim" ]]; then

--- a/zsh/.config/zsh/.zshrc
+++ b/zsh/.config/zsh/.zshrc
@@ -1,0 +1,85 @@
+# Zsh config — prompt + plugins + modular configs
+# Paths and exports handled by .zshenv (loaded before this file)
+
+[[ -o interactive ]] || return
+
+# --- Antidote plugin manager ---
+# Try ZDOTDIR-local install first, fall back to Homebrew
+if [[ -f "${ZDOTDIR:-$HOME}/.antidote/antidote.zsh" ]]; then
+  source "${ZDOTDIR:-$HOME}/.antidote/antidote.zsh"
+else
+  source "$(brew --prefix antidote)/share/antidote/antidote.zsh"
+fi
+antidote load "${ZDOTDIR:-$HOME}/.zsh_plugins.txt"
+
+# --- Zsh options (Fish-like behavior) ---
+setopt AUTO_CD              # cd by typing a directory name alone
+setopt AUTO_PUSHD           # Push dirs to stack automatically
+setopt PUSHD_IGNORE_DUPS    # No duplicate dirs in pushd stack
+setopt INTERACTIVE_COMMENTS # Allow # comments in interactive shell
+setopt HIST_IGNORE_ALL_DUPS # Remove older duplicate entries from history
+setopt HIST_SAVE_NO_DUPS    # Don't save duplicate history entries
+setopt HIST_REDUCE_BLANKS   # Remove superfluous blanks from history
+setopt HIST_IGNORE_SPACE    # Don't record commands starting with a space
+setopt SHARE_HISTORY        # Share history between all sessions
+setopt EXTENDED_HISTORY     # Record timestamp in history (: <time>:<elapsed>;<cmd>)
+setopt APPEND_HISTORY       # Append to, don't overwrite, history file
+setopt CORRECT              # Offer spelling correction
+
+HISTSIZE=10000
+SAVEHIST=10000
+HISTFILE="${ZDOTDIR:-$HOME}/.zsh_history"
+
+# --- Completions ---
+# Add custom completions directory to fpath before compinit
+fpath=("${ZDOTDIR:-$HOME}/completions" $fpath)
+
+autoload -Uz compinit
+
+# Only rebuild completion dump once per day (speeds up shell init)
+if [[ -n "${ZDOTDIR:-$HOME}/.zcompdump"(#qN.mh+24) ]]; then
+  compinit
+else
+  compinit -C
+fi
+
+zstyle ':completion:*' menu select
+zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'  # Case-insensitive tab complete
+zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
+zstyle ':completion:*:descriptions' format '%F{yellow}-- %d --%f'
+
+# --- Key bindings (emacs mode, matching Fish defaults) ---
+bindkey -e
+
+# History substring search — bind after plugin loads
+bindkey '^[[A' history-substring-search-up    # Up arrow
+bindkey '^[[B' history-substring-search-down  # Down arrow
+bindkey '^P'   history-substring-search-up    # Ctrl+P
+bindkey '^N'   history-substring-search-down  # Ctrl+N
+
+# --- chpwd hook: run eza after every directory change (like the custom cd.fish) ---
+chpwd() {
+  eza --long --all --header --git --icons --no-permissions --no-time --no-user --no-filesize --group-directories-first
+}
+
+# --- Autoload custom functions from functions/ ---
+fpath=("${ZDOTDIR:-$HOME}/functions" $fpath)
+autoload -Uz "${ZDOTDIR:-$HOME}/functions/"*(N.:t) 2>/dev/null
+
+# --- Source modular configs from .zshrc.d/ ---
+for conf in "${ZDOTDIR:-$HOME}/.zshrc.d/"*.zsh(N); do
+  source "$conf"
+done
+
+# --- Prompt engine (change ZSH_PROMPT in secrets.zsh to swap) ---
+ZSH_PROMPT="${ZSH_PROMPT:-starship}"
+
+case "$ZSH_PROMPT" in
+  starship)   eval "$(starship init zsh)" ;;
+  oh-my-posh) eval "$(oh-my-posh init zsh --config ~/.config/starship-ish.omp.json)" ;;
+esac
+
+# --- Nvim shell integration ---
+if [[ "$TERM_PROGRAM" == "nvim" ]]; then
+  source "$(nvim --locate-shell-integration-path zsh 2>/dev/null)" 2>/dev/null
+fi

--- a/zsh/.config/zsh/.zshrc
+++ b/zsh/.config/zsh/.zshrc
@@ -15,6 +15,9 @@ else
 fi
 antidote load "${ZDOTDIR:-$HOME}/.zsh_plugins.txt"
 
+# --- Autosuggestion ---
+ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=60"
+
 # --- Zsh options (Fish-like behavior) ---
 setopt AUTO_CD              # cd by typing a directory name alone
 setopt AUTO_PUSHD           # Push dirs to stack automatically

--- a/zsh/.config/zsh/.zshrc.d/01-paths.zsh
+++ b/zsh/.config/zsh/.zshrc.d/01-paths.zsh
@@ -1,0 +1,7 @@
+# PATH configuration — single source of truth (≈ paths.fish)
+# .zshenv handles most PATH setup; this file adds interactive-only PATH tweaks.
+# Using typeset -U path in .zshenv already deduplicates.
+
+# Nothing additional needed here — all PATH setup is in .zshenv
+# This file exists as a placeholder matching the Fish conf.d structure.
+# If you need interactive-only path additions, add them here.

--- a/zsh/.config/zsh/.zshrc.d/02-exports.zsh
+++ b/zsh/.config/zsh/.zshrc.d/02-exports.zsh
@@ -1,0 +1,5 @@
+# Environment variables — interactive-only additions (≈ exports.fish)
+# Non-interactive exports live in .zshenv; these are interactive extras.
+
+# Source secrets if present (gitignored)
+[[ -f "${ZDOTDIR:-$HOME}/secrets.zsh" ]] && source "${ZDOTDIR:-$HOME}/secrets.zsh"

--- a/zsh/.config/zsh/.zshrc.d/03-brew.zsh
+++ b/zsh/.config/zsh/.zshrc.d/03-brew.zsh
@@ -1,0 +1,8 @@
+# Homebrew integration (≈ brew.fish)
+# Primary setup done in .zshenv; this ensures shellenv is loaded interactively.
+
+if [[ -x /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -x /usr/local/bin/brew ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi

--- a/zsh/.config/zsh/.zshrc.d/04-ssh-agent.zsh
+++ b/zsh/.config/zsh/.zshrc.d/04-ssh-agent.zsh
@@ -1,0 +1,7 @@
+# Start ssh-agent and load SSH keys using macOS Keychain (≈ fish-ssh-agent.fish)
+
+if ! ssh-add -l &>/dev/null; then
+  eval "$(ssh-agent -s)" >/dev/null
+fi
+
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519 2>/dev/null

--- a/zsh/.config/zsh/.zshrc.d/05-aliases.zsh
+++ b/zsh/.config/zsh/.zshrc.d/05-aliases.zsh
@@ -1,0 +1,45 @@
+# Aliases (≈ _aliases.fish)
+# Direct translations from Fish aliases to Zsh.
+
+# Colorize grep output
+alias grep="grep --color=auto"
+alias egrep="egrep --color=auto"
+alias fgrep="fgrep --color=auto"
+
+# gitnow equivalents
+alias gcma="git add -A && git commit -S"
+alias gcm="git commit -S"
+alias gs="git status"
+
+# Confirm before overwriting
+alias cp="cp -Ri"
+alias mv="mv -i"
+alias rm="rm -i"
+
+# Navigation
+alias ..="cd .."
+alias ...="cd ../.."
+alias ....="cd ../../.."
+alias .....="cd ../../../.."
+alias ......="cd ../../../../.."
+
+# eza file listings
+alias l='eza --long --all --header --git --icons --no-permissions --no-time --no-user --no-filesize --group-directories-first'
+alias ll='eza -lagh --git --icons --group-directories-first'
+alias la='eza -lagh --git --icons --group-directories-first --sort modified'
+alias cll='clear && eza --long --all --header --git --icons --no-permissions --no-time --no-user --no-filesize --group-directories-first'
+alias tree='eza -Ta --icons --ignore-glob="node_modules|.git|.vscode|.DS_Store"'
+alias ltd='eza -TaD --icons --ignore-glob="node_modules|.git|.vscode|.DS_Store"'
+
+# Shortcuts
+alias fld='cd "/Users/ed/Library/Mobile Documents/iCloud~md~obsidian/Documents/FieldNotes✱"'
+alias fabric="fabric-ai"
+alias mux="tmux"
+alias zel="zellij"
+
+# Network
+alias ip='dig +short myip.opendns.com @resolver1.opendns.com'
+alias ipl='ipconfig getifaddr en0'
+alias ips='ifconfig -a | grep -o "inet6\? \(\([0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+\)\|[a-fA-F0-9:]\+\)" | sed -e "s/inet6* //"'
+alias sniff='sudo ngrep -d "en1" -t "^(GET|POST) " "tcp and port 80"'
+alias httpdump='sudo tcpdump -i en1 -n -s 0 -w - | grep -a -o -E "Host\: .* | GET \/.*"'

--- a/zsh/.config/zsh/.zshrc.d/06-abbr.zsh
+++ b/zsh/.config/zsh/.zshrc.d/06-abbr.zsh
@@ -1,0 +1,129 @@
+# cspell: disable
+# Abbreviations via zsh-abbr (≈ abbr.fish)
+# zsh-abbr persists abbreviations — this file defines them on first load.
+# Uses `abbr -S` for session abbreviations (non-persistent, defined every load)
+# or just `abbr` for user abbreviations (persistent, stored in zsh-abbr's data file).
+#
+# We use session abbreviations here since we manage them declaratively in dotfiles.
+
+# Window
+abbr -S cw='center_window' 2>/dev/null
+abbr -S cl='clear' 2>/dev/null
+
+# AI Agents + Models
+abbr -S ccc='claude converse --dangerously-skip-permissions' 2>/dev/null
+abbr -S cc='claude --dangerously-skip-permissions' 2>/dev/null
+abbr -S ccd='claude --dangerously-skip-permissions' 2>/dev/null
+abbr -S os='openspec' 2>/dev/null
+abbr -S oc='opencode' 2>/dev/null
+abbr -S occ='opencode --continue' 2>/dev/null
+abbr -S ocp='opencode --agent plan' 2>/dev/null
+abbr -S gg='gemini --yolo' 2>/dev/null
+abbr -S ag='antigravity' 2>/dev/null
+abbr -S ma='maestro-cli' 2>/dev/null
+abbr -S sa='sidecar' 2>/dev/null
+
+# Directories
+abbr -S config='~/.config/' 2>/dev/null
+abbr -S local='~/.local/' 2>/dev/null
+abbr -S wall='~/.wallpapers/' 2>/dev/null
+abbr -S dls='~/Downloads/' 2>/dev/null
+abbr -S goo='cd ~/.go/' 2>/dev/null
+
+# Editors/Terminals
+abbr -S gho='ghostty' 2>/dev/null
+abbr -S wez='wezterm' 2>/dev/null
+abbr -S kit='kitten' 2>/dev/null
+abbr -S zela='zellij a' 2>/dev/null
+abbr -S zels='zellij -s' 2>/dev/null
+abbr -S zelk='zellij k' 2>/dev/null
+abbr -S zelka='zellij ka' 2>/dev/null
+abbr -S zeld='zellij d' 2>/dev/null
+abbr -S zelda='zellij da' 2>/dev/null
+abbr -S zell='zellij ls' 2>/dev/null
+abbr -S muxa='tmux attach' 2>/dev/null
+abbr -S muxaa='tmux attach -t' 2>/dev/null
+abbr -S muxs='tmux new-session -s' 2>/dev/null
+abbr -S muxk='tmux kill-session -t' 2>/dev/null
+abbr -S muxka='tmux kill-server' 2>/dev/null
+abbr -S muxl='tmux list-sessions' 2>/dev/null
+abbr -S muxd='tmux detach' 2>/dev/null
+# vscode
+abbr -S co='code' 2>/dev/null
+abbr -S con='code -n .' 2>/dev/null
+abbr -S coo='code -r .' 2>/dev/null
+# zed
+abbr -S ze='zed' 2>/dev/null
+abbr -S zz='zed -n .' 2>/dev/null
+# neovim
+abbr -S vim='nvim' 2>/dev/null
+abbr -S nv='nvim' 2>/dev/null
+abbr -S v='nvim' 2>/dev/null
+abbr -S nn='nvim .' 2>/dev/null
+abbr -S vv='nvim .' 2>/dev/null
+
+# Utilities
+abbr -S atm='fastfetch' 2>/dev/null
+abbr -S cat='bat -pp' 2>/dev/null
+abbr -S clean='mac-cleaner-cli' 2>/dev/null
+abbr -S link='ln -s' 2>/dev/null
+abbr -S symlink='ln -s' 2>/dev/null
+
+# Git
+abbr -S lg='lazygit' 2>/dev/null
+abbr -S ghw='gh repo view --web' 2>/dev/null
+abbr -S ghpr='gh pr create -a "@me" --fill' 2>/dev/null
+abbr -S ghm='gh pr merge --merge' 2>/dev/null
+abbr -S ghr='gh release create --generate-notes --latest' 2>/dev/null
+
+# Package Managers
+abbr -S bi='brew install' 2>/dev/null
+abbr -S binfo='brew info' 2>/dev/null
+abbr -S brews='brew list' 2>/dev/null
+abbr -S casks='brew list --cask' 2>/dev/null
+abbr -S bic='brew install --cask' 2>/dev/null
+abbr -S cargos='cargo install --list' 2>/dev/null
+abbr -S eva='eval "$(ssh-agent -s)" && ssh-add --apple-use-keychain ~/.ssh/id_ed25519' 2>/dev/null
+abbr -S gems='gem list' 2>/dev/null
+abbr -S npms='npm list -g --depth=0' 2>/dev/null
+abbr -S pns='pnpm list -g' 2>/dev/null
+abbr -S pnpms='pnpm list -g' 2>/dev/null
+abbr -S buns='bun pm ls -g' 2>/dev/null
+abbr -S siz='du -khsc' 2>/dev/null
+abbr -S sp='speedtest -u Gbps' 2>/dev/null
+abbr -S spp='speedtest -u Gbps' 2>/dev/null
+abbr -S newcode='bunx --package yo --package generator-code -- yo code' 2>/dev/null
+abbr -S yy='yazi' 2>/dev/null
+abbr -S wr='wrangler' 2>/dev/null
+abbr -S upp='topgrade' 2>/dev/null
+abbr -S phps='php -S localhost:8888' 2>/dev/null
+abbr -S zip='ouch compress -q' 2>/dev/null
+abbr -S unzip='ouch decompress' 2>/dev/null
+abbr -S lzip='ouch list' 2>/dev/null
+
+# Migrated from aliases (simple 1:1 mappings)
+abbr -S md='mkdir -p' 2>/dev/null
+abbr -S cwd='pwd' 2>/dev/null
+abbr -S yp='pwd | pbcopy' 2>/dev/null
+abbr -S dev='cd ~/Developer' 2>/dev/null
+abbr -S work='cd ~/Developer' 2>/dev/null
+abbr -S sites='cd ~/Sites' 2>/dev/null
+abbr -S dots='cd ~/.dotfiles' 2>/dev/null
+abbr -S neoed='cd ~/.dotfiles/neoed/.config/nvim' 2>/dev/null
+abbr -S neo='cd ~/.dotfiles/neoed/.config/nvim' 2>/dev/null
+abbr -S e='$EDITOR' 2>/dev/null
+abbr -S o='open' 2>/dev/null
+abbr -S oo='open .' 2>/dev/null
+abbr -S oa='open -a' 2>/dev/null
+abbr -S del='trash' 2>/dev/null
+abbr -S sdel='sudo rm -rf' 2>/dev/null
+abbr -S serve='miniserve' 2>/dev/null
+abbr -S du='dua' 2>/dev/null
+abbr -S wget='wget -c' 2>/dev/null
+abbr -S whois='grc whois' 2>/dev/null
+abbr -S hostfile='sudo nvim /etc/hosts' 2>/dev/null
+abbr -S editssh='nvim ~/.ssh' 2>/dev/null
+abbr -S dk='docker' 2>/dev/null
+abbr -S dc='docker compose' 2>/dev/null
+abbr -S pn='pnpm' 2>/dev/null
+abbr -S px='pnpm dlx' 2>/dev/null

--- a/zsh/.config/zsh/.zshrc.d/06-abbr.zsh
+++ b/zsh/.config/zsh/.zshrc.d/06-abbr.zsh
@@ -5,6 +5,8 @@
 # or just `abbr` for user abbreviations (persistent, stored in zsh-abbr's data file).
 #
 # We use session abbreviations here since we manage them declaratively in dotfiles.
+# --quieter suppresses "Added the regular session abbreviation" stdout spam.
+ABBR_QUIETER=1
 
 # Window
 abbr -S cw='center_window' 2>/dev/null

--- a/zsh/.config/zsh/.zshrc.d/07-zellij.zsh
+++ b/zsh/.config/zsh/.zshrc.d/07-zellij.zsh
@@ -1,0 +1,26 @@
+# Zellij integration — auto-rename tabs based on CWD (≈ zellij.fish)
+# Uses Zsh chpwd hook (equivalent to Fish --on-variable PWD)
+
+if [[ -n "$ZELLIJ" ]]; then
+  _zellij_update_tabname() {
+    local tab_name git_root repo
+    if [[ "$PWD" == "$HOME" ]]; then
+      tab_name="~"
+    elif git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+      repo=$(basename "$git_root")
+      if [[ "$PWD" == "$git_root" ]]; then
+        tab_name="$repo"
+      else
+        tab_name="$repo/${PWD#$git_root/}"
+      fi
+    else
+      tab_name=$(basename "$PWD")
+    fi
+    command zellij action rename-tab "$tab_name" 2>/dev/null &!
+  }
+
+  chpwd_functions+=(_zellij_update_tabname)
+
+  # Set tab name on shell startup
+  _zellij_update_tabname
+fi

--- a/zsh/.config/zsh/.zshrc.d/08-mole.zsh
+++ b/zsh/.config/zsh/.zshrc.d/08-mole.zsh
@@ -1,0 +1,3 @@
+# Mole shell completion (≈ mole.fish)
+
+(( $+commands[mole] )) && eval "$(mole completion zsh)"

--- a/zsh/.config/zsh/.zshrc.d/09-keys.zsh
+++ b/zsh/.config/zsh/.zshrc.d/09-keys.zsh
@@ -1,0 +1,19 @@
+# FZF keybindings reference (≈ keys.fish)
+# Terminal emulators remap Cmd+Ctrl -> Ctrl+Alt
+# Ctrl+T   = Search files (fzf default)
+# Ctrl+R   = Search history (fzf default)
+# Alt+C    = cd into directory (fzf default)
+#
+# Ghostty remaps (if configured):
+# Cmd+Ctrl+F = Search Directory
+# Cmd+Ctrl+R = Search History
+# Cmd+Ctrl+L = Search Git Log
+# Cmd+Ctrl+S = Search Git Status
+
+# Source fzf keybindings and completion if installed via Homebrew
+if [[ -f "${HOMEBREW_PREFIX}/opt/fzf/shell/key-bindings.zsh" ]]; then
+  source "${HOMEBREW_PREFIX}/opt/fzf/shell/key-bindings.zsh"
+fi
+if [[ -f "${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh" ]]; then
+  source "${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh"
+fi

--- a/zsh/.config/zsh/.zshrc.d/10-lazy-fnm.zsh
+++ b/zsh/.config/zsh/.zshrc.d/10-lazy-fnm.zsh
@@ -1,0 +1,10 @@
+# Lazy-load FNM — only inits when node/npm/npx first called (≈ config.fish)
+
+__lazy_fnm() {
+  unfunction __lazy_fnm node npm npx 2>/dev/null
+  eval "$(fnm env --use-on-cd)"
+}
+
+node()  { __lazy_fnm && command node "$@"; }
+npm()   { __lazy_fnm && command npm "$@"; }
+npx()   { __lazy_fnm && command bunx "$@"; }  # npx → bunx (matching Fish config)

--- a/zsh/.config/zsh/.zshrc.d/11-lazy-rbenv.zsh
+++ b/zsh/.config/zsh/.zshrc.d/11-lazy-rbenv.zsh
@@ -1,0 +1,12 @@
+# Lazy-load rbenv — only inits when ruby/gem/bundle/rake/irb first called (≈ config.fish)
+
+__lazy_rbenv() {
+  unfunction __lazy_rbenv ruby gem bundle rake irb 2>/dev/null
+  eval "$(rbenv init -)"
+}
+
+ruby()   { __lazy_rbenv && command ruby "$@"; }
+gem()    { __lazy_rbenv && command gem "$@"; }
+bundle() { __lazy_rbenv && command bundle "$@"; }
+rake()   { __lazy_rbenv && command rake "$@"; }
+irb()    { __lazy_rbenv && command irb "$@"; }

--- a/zsh/.config/zsh/.zshrc.d/12-lazy-zoxide.zsh
+++ b/zsh/.config/zsh/.zshrc.d/12-lazy-zoxide.zsh
@@ -1,0 +1,9 @@
+# Lazy-load zoxide — only inits on first z/zi call (≈ zoxide.fish)
+
+__lazy_zoxide() {
+  unfunction __lazy_zoxide z zi 2>/dev/null
+  eval "$(zoxide init zsh)"
+}
+
+z()  { __lazy_zoxide && __zoxide_z "$@"; }
+zi() { __lazy_zoxide && __zoxide_zi "$@"; }

--- a/zsh/.config/zsh/completions/_alacritty
+++ b/zsh/.config/zsh/completions/_alacritty
@@ -1,0 +1,25 @@
+#compdef alacritty
+
+_alacritty() {
+  _arguments \
+    '(-v --version)'{-v,--version}'[Prints version information]' \
+    '(-h --help)'{-h,--help}'[Prints help information]' \
+    '--live-config-reload[Enable automatic config reloading]' \
+    '--no-live-config-reload[Disable automatic config reloading]' \
+    '--persistent-logging[Keep the log file after quitting]' \
+    '--config-file[Specify an alternative config file]:file:_files' \
+    '(-t --title)'{-t,--title}'[Defines the window title]:title:' \
+    '--class[Defines the window class]:class:' \
+    '--embed[Defines the X11 window ID to embed within]:id:' \
+    '--working-directory[Start shell in specified directory]:dir:_directories' \
+    '--hold[Remain open after child process exits]' \
+    '--print-events[Print all events to stdout]' \
+    '-q[Reduces verbosity]' \
+    '-qq[Reduces verbosity further]' \
+    '--ref-test[Generates ref test]' \
+    '(-d --dimensions)'{-d,--dimensions}'[Window dimensions]:columns lines:' \
+    '--position[Window position]:x-pos y-pos:' \
+    '(-e --command)'{-e,--command}'[Execute command (must be last arg)]:command:_command_names'
+}
+
+_alacritty "$@"

--- a/zsh/.config/zsh/completions/_fab
+++ b/zsh/.config/zsh/completions/_fab
@@ -1,0 +1,41 @@
+#compdef fab
+
+# Zsh completions for 'fab' (alias for fabric-ai)
+
+_fab_get_patterns()  { fab --listpatterns --shell-complete-list 2>/dev/null }
+_fab_get_models()    { fab --listmodels --shell-complete-list 2>/dev/null }
+_fab_get_vendors()   { fab --listvendors --shell-complete-list 2>/dev/null }
+_fab_get_contexts()  { fab --listcontexts --shell-complete-list 2>/dev/null }
+_fab_get_sessions()  { fab --listsessions --shell-complete-list 2>/dev/null }
+_fab_get_strategies(){ fab --liststrategies --shell-complete-list 2>/dev/null }
+_fab_get_extensions(){ fab --listextensions --shell-complete-list 2>/dev/null }
+
+_fab() {
+  _arguments \
+    '(-p --pattern)'{-p,--pattern}'[Choose a pattern]:pattern:($(_fab_get_patterns))' \
+    '(-v --variable)'{-v,--variable}'[Pattern variable values]' \
+    '(-C --context)'{-C,--context}'[Choose a context]:context:($(_fab_get_contexts))' \
+    '--session[Choose a session]:session:($(_fab_get_sessions))' \
+    '(-a --attachment)'{-a,--attachment}'[Attachment path or URL]:file:_files' \
+    '(-t --temperature)'{-t,--temperature}'[Set temperature]' \
+    '(-T --topp)'{-T,--topp}'[Set top P]' \
+    '(-m --model)'{-m,--model}'[Choose model]:model:($(_fab_get_models))' \
+    '(-V --vendor)'{-V,--vendor}'[Specify vendor]:vendor:($(_fab_get_vendors))' \
+    '(-o --output)'{-o,--output}'[Output to file]:file:_files' \
+    '(-y --youtube)'{-y,--youtube}'[YouTube URL]' \
+    '(-u --scrape_url)'{-u,--scrape_url}'[Scrape URL to markdown]' \
+    '--strategy[Choose a strategy]:strategy:($(_fab_get_strategies))' \
+    '--thinking[Reasoning level]:(off low medium high)' \
+    '(-S --setup)'{-S,--setup}'[Run setup]' \
+    '(-s --stream)'{-s,--stream}'[Stream output]' \
+    '(-r --raw)'{-r,--raw}'[Use model defaults]' \
+    '(-l --listpatterns)'{-l,--listpatterns}'[List all patterns]' \
+    '(-L --listmodels)'{-L,--listmodels}'[List all models]' \
+    '(-c --copy)'{-c,--copy}'[Copy to clipboard]' \
+    '(-U --updatepatterns)'{-U,--updatepatterns}'[Update patterns]' \
+    '--serve[Serve the Fabric REST API]' \
+    '--version[Print current version]' \
+    '(-h --help)'{-h,--help}'[Show help message]'
+}
+
+_fab "$@"

--- a/zsh/.config/zsh/completions/_obsidian-cli
+++ b/zsh/.config/zsh/completions/_obsidian-cli
@@ -1,0 +1,33 @@
+#compdef obsidian-cli
+
+# Zsh completion for obsidian-cli (Cobra-based CLI)
+# Auto-generated completions via __complete command
+
+_obsidian-cli() {
+  local -a completions
+  local -a flags
+  local lastParam lastChar flagPrefix requestComp
+
+  requestComp="${words[1]} __complete ${words[2,-1]}"
+
+  local -a results
+  results=(${(f)"$(eval "$requestComp" 2>/dev/null)"})
+
+  local directive="${results[-1]}"
+  results=("${results[1,-2]}")
+
+  local -a completions_with_desc
+  for line in "${results[@]}"; do
+    if [[ "$line" == *$'\t'* ]]; then
+      local comp="${line%%$'\t'*}"
+      local desc="${line#*$'\t'}"
+      completions_with_desc+=("$comp:$desc")
+    else
+      completions_with_desc+=("$line")
+    fi
+  done
+
+  _describe -t completions 'obsidian-cli' completions_with_desc
+}
+
+_obsidian-cli "$@"

--- a/zsh/.config/zsh/completions/_voicemode
+++ b/zsh/.config/zsh/completions/_voicemode
@@ -1,0 +1,9 @@
+#compdef voicemode
+
+_voicemode() {
+  local -a completions
+  completions=(${(f)"$(env _VOICEMODE_COMPLETE=zsh_complete voicemode 2>/dev/null)"})
+  compadd -a completions
+}
+
+_voicemode "$@"

--- a/zsh/.config/zsh/functions/__git_branch_has_wip
+++ b/zsh/.config/zsh/functions/__git_branch_has_wip
@@ -1,0 +1,4 @@
+# Returns 0 if branch has --wip--, otherwise 1
+__git_branch_has_wip() {
+  git log -n 1 2>/dev/null | grep -qc "\-\-wip\-\-"
+}

--- a/zsh/.config/zsh/functions/__git_current_branch
+++ b/zsh/.config/zsh/functions/__git_current_branch
@@ -1,0 +1,5 @@
+# Output git's current branch name
+__git_current_branch() {
+  git symbolic-ref HEAD 2>/dev/null | sed -e 's|^refs/heads/||' \
+    || git rev-parse --short HEAD 2>/dev/null
+}

--- a/zsh/.config/zsh/functions/__git_default_branch
+++ b/zsh/.config/zsh/functions/__git_default_branch
@@ -1,0 +1,13 @@
+# Use init.defaultBranch if set and exists, otherwise main, falls back to master
+__git_default_branch() {
+  command git rev-parse --git-dir &>/dev/null || return
+  local default_branch
+  default_branch=$(command git config --get init.defaultBranch)
+  if [[ -n "$default_branch" ]] && command git show-ref -q --verify "refs/heads/$default_branch"; then
+    echo "$default_branch"
+  elif command git show-ref -q --verify refs/heads/main; then
+    echo main
+  else
+    echo master
+  fi
+}

--- a/zsh/.config/zsh/functions/__git_delete_branches
+++ b/zsh/.config/zsh/functions/__git_delete_branches
@@ -1,0 +1,12 @@
+# Delete multiple git branches
+# Usage: __git_delete_branches [-f|--force] branch1 branch2 ...
+__git_delete_branches() {
+  local delete_flag="-d"
+  if [[ "$1" == "-f" || "$1" == "--force" ]]; then
+    delete_flag="-D"
+    shift
+  fi
+  for branch in "$@"; do
+    git branch "$delete_flag" "$branch"
+  done
+}

--- a/zsh/.config/zsh/functions/abbrex
+++ b/zsh/.config/zsh/functions/abbrex
@@ -1,0 +1,16 @@
+# Utility for expanding abbreviations
+abbrex() {
+  if (( $# == 0 )); then
+    echo "Usage: abbrex <abbreviation> [args...]"
+    return 1
+  fi
+  local abbr_name="$1"
+  shift
+  local expansion
+  expansion=$(abbr list 2>/dev/null | grep "^$abbr_name=" | sed "s/^$abbr_name=//; s/^'//; s/'$//")
+  if [[ -n "$expansion" ]]; then
+    echo "$expansion $*"
+  else
+    echo "$abbr_name $*"
+  fi
+}

--- a/zsh/.config/zsh/functions/batthemes
+++ b/zsh/.config/zsh/functions/batthemes
@@ -1,0 +1,4 @@
+# List all bat themes with a preview
+batthemes() {
+  bat --list-themes | fzf --preview="bat --theme={} --color=always Makefile" | pbcopy
+}

--- a/zsh/.config/zsh/functions/center_window
+++ b/zsh/.config/zsh/functions/center_window
@@ -1,0 +1,4 @@
+# Center Window with Raycast
+center_window() {
+  open -g 'raycast://customWindowManagementCommand?&name=Center%20Center&position=center&relativeWidth=0.6&relativeHeight=1.0'
+}

--- a/zsh/.config/zsh/functions/claude-models
+++ b/zsh/.config/zsh/functions/claude-models
@@ -1,0 +1,15 @@
+# List latest Claude models (opus, sonnet, haiku)
+claude-models() {
+  curl -s "https://api.anthropic.com/v1/models?limit=100" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "x-api-key: $ANTHROPIC_API_KEY" \
+  | jq -r '
+      .data
+      | map(select(.id | test("opus|sonnet|haiku")))
+      | group_by(.id | capture("(?<family>opus|sonnet|haiku)").family)
+      | map(.[0:3])
+      | flatten
+      | .[]
+      | "\(.id)\t\(.display_name)"
+  '
+}

--- a/zsh/.config/zsh/functions/colormap
+++ b/zsh/.config/zsh/functions/colormap
@@ -1,0 +1,4 @@
+# Check terminal color support and print color palette
+colormap() {
+  "$HOME/.config/fish/utils/color-map.sh"
+}

--- a/zsh/.config/zsh/functions/confetti
+++ b/zsh/.config/zsh/functions/confetti
@@ -1,0 +1,4 @@
+# Make it rain confetti
+confetti() {
+  open "raycast://extensions/raycast/raycast/confetti"
+}

--- a/zsh/.config/zsh/functions/cpwd
+++ b/zsh/.config/zsh/functions/cpwd
@@ -1,0 +1,4 @@
+# pwd copied to clipboard
+cpwd() {
+  command pwd | tr -d '\n' | pbcopy && echo 'pwd copied to clipboard'
+}

--- a/zsh/.config/zsh/functions/doom
+++ b/zsh/.config/zsh/functions/doom
@@ -1,0 +1,4 @@
+# Terminal Doom
+doom() {
+  cd "$HOME/Developer/games/terminal-doom" && zig-out/bin/terminal-doom
+}

--- a/zsh/.config/zsh/functions/ex
+++ b/zsh/.config/zsh/functions/ex
@@ -1,0 +1,4 @@
+# Alias for exit
+ex() {
+  exit
+}

--- a/zsh/.config/zsh/functions/flashEthernet
+++ b/zsh/.config/zsh/functions/flashEthernet
@@ -1,0 +1,11 @@
+# Disable and re-enable the Ethernet network interface
+flashEthernet() {
+  local interface="Ethernet"
+  if sudo networksetup -setnetworkserviceenabled "$interface" off && \
+     sleep 1 && \
+     sudo networksetup -setnetworkserviceenabled "$interface" on; then
+    echo "$interface successfully disabled and will re-enable shortly."
+  else
+    echo "Failed to disable and re-enable $interface."
+  fi
+}

--- a/zsh/.config/zsh/functions/gbda
+++ b/zsh/.config/zsh/functions/gbda
@@ -1,0 +1,30 @@
+# Delete all branches merged in current HEAD, including squashed
+gbda() {
+  local default_branch
+  default_branch=$(__git_default_branch)
+
+  # Handle --gone flag
+  if [[ "$1" == "-g" || "$1" == "--gone" ]]; then
+    __git_delete_branches --force $(
+      git for-each-ref refs/heads/ --format="%(refname:short) %(upstream:track)" | \
+        command awk '$2 == "[gone]" { print $1 }'
+    )
+  fi
+
+  # Delete merged branches
+  __git_delete_branches $(
+    git branch --merged | \
+      command grep -vE '^\*|^\+|^\s*(master|main|develop)\s*$' | \
+      tr -d ' '
+  )
+
+  # Delete squash-merged branches
+  git for-each-ref refs/heads/ "--format=%(refname:short)" | \
+    while read -r branch; do
+      local merge_base
+      merge_base=$(git merge-base "$default_branch" "$branch")
+      if [[ "$(git cherry "$default_branch" "$(git commit-tree "$(git rev-parse "${branch}^{tree}")" -p "$merge_base" -m _)")" == -* ]]; then
+        __git_delete_branches --force "$branch"
+      fi
+    done
+}

--- a/zsh/.config/zsh/functions/grename
+++ b/zsh/.config/zsh/functions/grename
@@ -1,0 +1,9 @@
+# Rename 'old' branch to 'new', including in origin remote
+grename() {
+  if (( $# != 2 )); then
+    echo "Usage: grename old_branch new_branch"
+    return 1
+  fi
+  git branch -m "$1" "$2"
+  git push origin :"$1" && git push --set-upstream origin "$2"
+}

--- a/zsh/.config/zsh/functions/grt
+++ b/zsh/.config/zsh/functions/grt
@@ -1,0 +1,4 @@
+# cd into the top of the current repository or submodule
+grt() {
+  cd "$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+}

--- a/zsh/.config/zsh/functions/gunwip
+++ b/zsh/.config/zsh/functions/gunwip
@@ -1,0 +1,4 @@
+# git uncommit the work-in-progress branch
+gunwip() {
+  git log -n 1 | grep -q -c "\--wip--" && git reset HEAD~1
+}

--- a/zsh/.config/zsh/functions/gwip
+++ b/zsh/.config/zsh/functions/gwip
@@ -1,0 +1,6 @@
+# git commit a work-in-progress branch
+gwip() {
+  git add -A
+  git rm $(git ls-files --deleted) 2>/dev/null
+  git commit -m "--wip--" --no-verify
+}

--- a/zsh/.config/zsh/functions/imgcon
+++ b/zsh/.config/zsh/functions/imgcon
@@ -1,0 +1,13 @@
+# Recursive ImageMagick converter
+# Usage: imgcon <from_ext> <to_ext>
+imgcon() {
+  if (( $# != 2 )); then
+    echo "Usage: imgcon <from_extension> <to_extension>"
+    return 1
+  fi
+  local from="$1" to="$2"
+  for image in **/*."$from"; do
+    [[ -f "$image" ]] || continue
+    convert -verbose "$image" "${image%.$from}.$to"
+  done
+}

--- a/zsh/.config/zsh/functions/killws
+++ b/zsh/.config/zsh/functions/killws
@@ -1,0 +1,4 @@
+# Restart the WindowServer on macOS (this will log you out)
+killws() {
+  sudo killall -HUP WindowServer
+}

--- a/zsh/.config/zsh/functions/lssh
+++ b/zsh/.config/zsh/functions/lssh
@@ -1,0 +1,4 @@
+# List ssh hosts
+lssh() {
+  grep -w -i Host ~/.ssh/config | sed s/Host//
+}

--- a/zsh/.config/zsh/functions/matrix
+++ b/zsh/.config/zsh/functions/matrix
@@ -1,0 +1,4 @@
+# Matrix-style screensaver for your terminal
+matrix() {
+  "$HOME/.config/fish/utils/matrix.sh"
+}

--- a/zsh/.config/zsh/functions/mkbak
+++ b/zsh/.config/zsh/functions/mkbak
@@ -1,0 +1,4 @@
+# Create a .bak copy of a file
+mkbak() {
+  cp -- "$1" "$1.bak"
+}

--- a/zsh/.config/zsh/functions/mkd
+++ b/zsh/.config/zsh/functions/mkd
@@ -1,0 +1,4 @@
+# Make a directory and cd into it (includes -p option)
+mkd() {
+  mkdir -p "$@" && cd "${@[-1]}"
+}

--- a/zsh/.config/zsh/functions/nvn
+++ b/zsh/.config/zsh/functions/nvn
@@ -1,0 +1,4 @@
+# Open a new file in neovim from clipboard contents
+nvn() {
+  nvim -c 'enew | put +' -c startinsert
+}

--- a/zsh/.config/zsh/functions/pubkey
+++ b/zsh/.config/zsh/functions/pubkey
@@ -1,0 +1,10 @@
+# Copy public SSH key to clipboard
+pubkey() {
+  if [[ -f ~/.ssh/id_rsa.pub ]]; then
+    cat ~/.ssh/id_rsa.pub | pbcopy && echo '=> Public key copied to clipboard.'
+  elif [[ -f ~/.ssh/id_ed25519.pub ]]; then
+    cat ~/.ssh/id_ed25519.pub | pbcopy && echo '=> Public key copied to clipboard.'
+  else
+    echo 'No public key found.'
+  fi
+}

--- a/zsh/.config/zsh/functions/reload
+++ b/zsh/.config/zsh/functions/reload
@@ -1,0 +1,4 @@
+# Reload shell configuration
+reload() {
+  exec zsh
+}

--- a/zsh/.config/zsh/functions/restore
+++ b/zsh/.config/zsh/functions/restore
@@ -1,0 +1,5 @@
+# Restore a file from a .bak file
+restore() {
+  local original="${1%.bak}"
+  mv -- "$1" "$original"
+}

--- a/zsh/.config/zsh/functions/setup
+++ b/zsh/.config/zsh/functions/setup
@@ -1,0 +1,4 @@
+# Defines one-time abbreviations for the current shell
+setup() {
+  abbr -S lzd='lazydocker' 2>/dev/null
+}

--- a/zsh/.config/zsh/functions/speed
+++ b/zsh/.config/zsh/functions/speed
@@ -1,0 +1,8 @@
+# Network speed test (alias for networkQuality)
+speed() {
+  if (( $# > 0 )); then
+    command networkQuality "$@"
+  else
+    command networkQuality -v
+  fi
+}

--- a/zsh/.config/zsh/functions/theme
+++ b/zsh/.config/zsh/functions/theme
@@ -1,0 +1,23 @@
+# Switch color theme across all apps
+theme() {
+  local themes_dir="$HOME/.config/theme-switcher"
+  local script="$themes_dir/theme-switcher.sh"
+
+  if [[ ! -x "$script" ]]; then
+    echo "Error: Theme switcher script not found at $script" >&2
+    return 1
+  fi
+
+  if (( $# == 0 )); then
+    "$script"
+  else
+    "$script" "$1"
+  fi
+
+  # Re-initialize oh-my-posh with new palette if it's the active prompt
+  if [[ "$ZSH_PROMPT" == "oh-my-posh" ]]; then
+    eval "$(oh-my-posh init zsh --config ~/.config/starship-ish.omp.json)"
+    echo ""
+    echo -e "\033[0;32m✓\033[0m Prompt refreshed with new theme"
+  fi
+}

--- a/zsh/.config/zsh/functions/tldrf
+++ b/zsh/.config/zsh/functions/tldrf
@@ -1,0 +1,4 @@
+# tldr search and preview with fzf
+tldrf() {
+  tldr --list | fzf --preview "tldr {1} --color=always" --preview-window=right,70% | xargs tldr
+}

--- a/zsh/.config/zsh/functions/weather
+++ b/zsh/.config/zsh/functions/weather
@@ -1,0 +1,4 @@
+# Check the weather
+weather() {
+  curl 'wttr.in/~Springboro+Ohio?u'
+}

--- a/zsh/.config/zsh/secrets.zsh.example
+++ b/zsh/.config/zsh/secrets.zsh.example
@@ -1,0 +1,9 @@
+# Zsh secrets — copy to secrets.zsh and fill in your keys
+# This file is gitignored. NEVER commit actual secrets.
+#
+# Usage: cp secrets.zsh.example secrets.zsh && nvim secrets.zsh
+# The secrets file is sourced from .zshrc.d/ if present.
+
+export ANTHROPIC_API_KEY=""
+export OPENAI_API_KEY=""
+# Add additional API keys as needed

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,0 +1,6 @@
+# Bootstrap: point Zsh to XDG-compliant config directory
+# This is the only file that lives in $HOME — everything else is under ZDOTDIR.
+export ZDOTDIR="$HOME/.config/zsh"
+
+# Source the real .zshenv from ZDOTDIR
+[[ -f "$ZDOTDIR/.zshenv" ]] && source "$ZDOTDIR/.zshenv"


### PR DESCRIPTION
## Summary
Migrate from Fish shell to Zsh with feature parity, including a complete modular configuration structure, abbreviations system, custom functions, and shell integrations.

## Key Changes

### Core Configuration
- **`.zshenv`** – Non-interactive environment setup with PATH management, Homebrew detection (Apple Silicon + Intel), XDG Base Directory compliance, and tool-specific exports (Go, Node/PNPM, Bun, Python/pyenv, Rust, Ruby, PHP)
- **`.zshrc`** – Interactive shell initialization with Antidote plugin manager, Zsh options (Fish-like behavior), completion setup, key bindings, and modular config sourcing
- **Modular `.zshrc.d/` configs** – Organized by function:
  - `01-paths.zsh` – PATH configuration
  - `02-exports.zsh` – Interactive-only environment variables and secrets sourcing
  - `03-brew.zsh` – Homebrew shellenv integration
  - `04-ssh-agent.zsh` – SSH agent with macOS Keychain support
  - `05-aliases.zsh` – Direct Fish-to-Zsh alias translations (grep, git, navigation, eza, network)
  - `06-abbr.zsh` – 100+ session abbreviations (AI agents, editors, utilities, git, package managers)
  - `07-zellij.zsh` – Zellij tab auto-rename based on CWD and git context
  - `08-mole.zsh` – Mole shell completion
  - `09-keys.zsh` – FZF keybindings reference and sourcing
  - `10-lazy-fnm.zsh` – Lazy-load FNM for Node.js
  - `11-lazy-rbenv.zsh` – Lazy-load rbenv for Ruby
  - `12-lazy-zoxide.zsh` – Lazy-load zoxide for smart directory navigation

### Plugin Management
- **`.zsh_plugins.txt`** – Antidote plugin declarations:
  - `zsh-autosuggestions` – Inline history suggestions (Fish feature)
  - `fast-syntax-highlighting` – Real-time syntax coloring
  - `zsh-abbr` – Fish-style abbreviations with inline expansion
  - `zsh-history-substring-search` – Up/down arrow history search
  - `zsh-autopair` – Auto-close brackets/quotes/parens
  - `zsh-completions` – Additional completion definitions

### Custom Functions (30+ utilities)
- **Git helpers**: `__git_current_branch`, `__git_default_branch`, `__git_delete_branches`, `gbda` (delete merged branches), `grename`, `gwip`, `gunwip`, `grt`
- **Utilities**: `abbrex`, `batthemes`, `center_window`, `colormap`, `confetti`, `cpwd`, `doom`, `ex`, `flashEthernet`, `imgcon`, `killws`, `lssh`, `matrix`, `mkbak`, `mkd`, `nvn`, `pubkey`, `reload`, `restore`, `setup`, `speed`, `theme`, `tldrf`, `weather`
- **API integrations**: `claude-models` (fetch latest Claude models from Anthropic API)

### Shell Completions
- **`_fab`** – Fabric-ai pattern/model/vendor/context/session completions
- **`_obsidian-cli`** – Obsidian CLI Cobra-based completions
- **`_alacritty`** – Alacritty terminal emulator completions
- **`_voicemode`** – Voice mode CLI completions

### Bootstrap & Secrets
- **`zsh/.zshenv`** – Root-level bootstrap that sets `ZDOTDIR` and sources the real config
- **`secrets.zsh.example`** – Template for API keys (gitignored in actual use)

## Notable Implementation Details

- **Fish parity**: Abbreviations use `abbr -S` (session, non-persistent) to manage them declaratively in dotfiles rather than pers

https://claude.ai/code/session_01Tmo45gA3dGCW8RTidzFdPL