### PR TITLE
aup: space harness updates and wrap Prime npm 12

### DIFF
--- a/fish/.config/fish/agent-harnesses.txt
+++ b/fish/.config/fish/agent-harnesses.txt
@@ -17,11 +17,11 @@
 #
 
 
-Claude        | ff8c42 | claude      | claude | update
-Pi+Extensions | ff69b4 | pi          | -      | update --all
+Claude Code   | ff8c42 | claude      | claude | update
+Pi extensions | ff69b4 | pi          | -      | update --all
 OMP           | af87ff | omp         | omp    | update --force
 OMP plugins   | af87ff | omp         | omp    | plugins upgrade
-Jcode         | 5fff87 | jcode       | jcode  | update
+J code        | 5fff87 | jcode       | jcode  | update
 Prime-agent   | 61747f | prime-agent | -      | update --force
 Opencode      | 61747f | opencode | opencode | upgrade
 Herdr         | 5fd7ff | herdr       | herdr  | update

--- a/fish/.config/fish/functions/aup.fish
+++ b/fish/.config/fish/functions/aup.fish
@@ -1,9 +1,88 @@
+function __aup_prime_agent_update --description 'Run prime-agent update with a temporary npmCommand wrapper'
+    set -l wrapdir (mktemp -d)
+    set -l wrapper $wrapdir/npm
+    set -l restore $wrapdir/restore.py
+    set -l meta $wrapdir/meta.json
+    set -l real_npm (command -s npm)
+    set -l py (command -s python3)
+    set -l prefix (path dirname (path dirname (command -s prime-agent)))
+    set -l settings $HOME/.prime/agent/settings.json
+    printf '%s\n' \
+        'import json, os, sys' \
+        'settings, meta = sys.argv[1:3]' \
+        'if not os.path.isfile(meta):' \
+        '    raise SystemExit(1)' \
+        'with open(meta) as f:' \
+        '    m = json.load(f)' \
+        'if not os.path.isfile(settings):' \
+        '    raise SystemExit(0 if m.get("created") else 1)' \
+        'with open(settings) as f:' \
+        '    data = json.load(f) or {}' \
+        'if m.get("had"):' \
+        '    data["npmCommand"] = m.get("orig")' \
+        'else:' \
+        '    data.pop("npmCommand", None)' \
+        'if data:' \
+        '    with open(settings, "w") as f:' \
+        '        json.dump(data, f, indent=2)' \
+        '        f.write("\n")' \
+        'elif m.get("created"):' \
+        '    os.remove(settings)' \
+        'else:' \
+        '    with open(settings, "w") as f:' \
+        '        json.dump(data, f, indent=2)' \
+        '        f.write("\n")' >$restore
+    printf '%s\n' \
+        '#!/bin/sh' \
+        "real_npm='$real_npm'" \
+        "py='$py'" \
+        "restore='$restore'" \
+        "settings='$settings'" \
+        "meta='$meta'" \
+        'for arg in "$@"; do' \
+        '  case "$arg" in' \
+        '  https://*.r2.dev/releases/*/prime-agent-*.tgz)' \
+        '    "$py" "$restore" "$settings" "$meta" || exit 1' \
+        '    exec "$real_npm" --allow-remote=all --dangerously-allow-all-scripts "$@"' \
+        '    ;;' \
+        '  esac' \
+        'done' \
+        'exec "$real_npm" "$@"' >$wrapper
+    chmod +x $wrapper
+    python3 -c 'import json, os, sys
+settings, wrapper, meta, prefix = sys.argv[1:5]
+created = not os.path.isfile(settings)
+data = {}
+if not created:
+    with open(settings) as f:
+        data = json.load(f) or {}
+with open(meta, "w") as f:
+    json.dump({"had": "npmCommand" in data, "orig": data.get("npmCommand"), "created": created}, f)
+data["npmCommand"] = [wrapper, "--prefix", prefix]
+os.makedirs(os.path.dirname(settings), exist_ok=True)
+with open(settings, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+' $settings $wrapper $meta $prefix
+    or begin
+        rm -rf $wrapdir
+        return 1
+    end
+    command prime-agent $argv
+    set -l st $status
+    python3 $restore $settings $meta
+    rm -rf $wrapdir
+    return $st
+end
+
 function __aup_run --description 'Run one update command and report its result'
     set -l label $argv[1]
     set -l color $argv[2]
     set -l binary $argv[3]
     set -l version_command $argv[4]
     set -l update_args $argv[5..-1]
+
+    printf '\n'
 
     if not command -q $binary
         set_color brblack
@@ -12,8 +91,19 @@ function __aup_run --description 'Run one update command and report its result'
         return 0
     end
 
-    command $binary $update_args
+    set_color --bold $color
+    printf '%s update in progress\n' "$label"
+    set_color normal
+    printf '\n'
+
+    if test "$binary" = prime-agent
+        __aup_prime_agent_update $update_args
+    else
+        command $binary $update_args
+    end
     set -l update_status $status
+
+    printf '\n'
 
     if test $update_status -eq 0
         set_color $color
@@ -75,5 +165,6 @@ function aup --description 'Update installed agent harnesses and extensions'
         or set failed 1
     end <"$manifest"
 
+    printf '\n'
     return $failed
 end


### PR DESCRIPTION
`aup` prints a colored in-progress headline around each harness so updater output does not run together. Manifest labels are Claude Code, Pi extensions, and J code.

Prime Agent still updates via `prime-agent update`. Node prepends its own bin, so PATH cannot intercept npm. For the update only, aup sets `npmCommand` to a temp wrapper plus the install prefix; the wrapper adds `--allow-remote=all --dangerously-allow-all-scripts` only when argv is the Prime CDN tarball. Settings are restored afterward. Verified: npm argv includes both flags, `npm root -g` stays unflagged, 0.8.1 remains installed, wrapper and settings are gone.