### PR TITLE
Chore Aup Harness Order

### DIFF
--- a/config/.config/flashspace/profiles.json
+++ b/config/.config/flashspace/profiles.json
@@ -101,11 +101,6 @@
               "name" : "ChatGPT"
             },
             {
-              "bundleIdentifier" : "com.maestro.app",
-              "iconPath" : "/Applications/Maestro.app/Contents/Resources/icon.icns",
-              "name" : "Maestro"
-            },
-            {
               "bundleIdentifier" : "com.anysphere.sand",
               "iconPath" : "/Applications/Grok Bot.app/Contents/Resources/icon.icns",
               "name" : "Grok Bot"
@@ -114,6 +109,11 @@
               "bundleIdentifier" : "com.zed-industries.delta",
               "iconPath" : "/Applications/Delta.app/Contents/Resources/AppIcon.icns",
               "name" : "Delta"
+            },
+            {
+              "bundleIdentifier" : "com.madda.ghostex.host",
+              "iconPath" : "/Applications/ghostex.app/Contents/Resources/AppIcon.icns",
+              "name" : "Ghostex"
             }
           ],
           "display" : "PA278QV",

--- a/config/.config/flashspace/profiles.json
+++ b/config/.config/flashspace/profiles.json
@@ -25,6 +25,11 @@
               "bundleIdentifier" : "org.mozilla.firefox",
               "iconPath" : "/Applications/Firefox.app/Contents/Resources/firefox.icns",
               "name" : "Firefox"
+            },
+            {
+              "bundleIdentifier" : "com.tigervnc.tigervnc",
+              "iconPath" : "/Applications/TigerVNC.app/Contents/Resources/tigervnc.icns",
+              "name" : "TigerVNC"
             }
           ],
           "display" : "PA278QV",
@@ -59,6 +64,11 @@
               "bundleIdentifier" : "net.kovidgoyal.kitty",
               "iconPath" : "/Applications/kitty.app/Contents/Resources/kitty.icns",
               "name" : "kitty"
+            },
+            {
+              "bundleIdentifier" : "dev.kdrag0n.MacVirt",
+              "iconPath" : "/Applications/OrbStack.app/Contents/Resources/AppIcon.icns",
+              "name" : "OrbStack"
             }
           ],
           "display" : "PA278QV",
@@ -114,6 +124,11 @@
               "bundleIdentifier" : "com.madda.ghostex.host",
               "iconPath" : "/Applications/ghostex.app/Contents/Resources/AppIcon.icns",
               "name" : "Ghostex"
+            },
+            {
+              "bundleIdentifier" : "app.omlx",
+              "iconPath" : "/Applications/oMLX.app/Contents/Resources/AppIcon.icns",
+              "name" : "oMLX"
             }
           ],
           "display" : "PA278QV",
@@ -233,11 +248,6 @@
               "bundleIdentifier" : "com.dygmalab.bazecor",
               "iconPath" : "/Applications/Bazecor.app/Contents/Resources/electron.icns",
               "name" : "Bazecor"
-            },
-            {
-              "bundleIdentifier" : "com.tigervnc.tigervnc",
-              "iconPath" : "/Applications/TigerVNC.app/Contents/Resources/tigervnc.icns",
-              "name" : "TigerVNC"
             },
             {
               "bundleIdentifier" : "com.apple.iCal",

--- a/config/.config/flashspace/settings.json
+++ b/config/.config/flashspace/settings.json
@@ -25,6 +25,11 @@
       "bundleIdentifier" : "com.raycast.safari-extension",
       "iconPath" : "/Applications/Raycast Companion.app/Contents/Resources/AppIcon.icns",
       "name" : "Raycast Companion"
+    },
+    {
+      "bundleIdentifier" : "com.madda.ghostex.host",
+      "iconPath" : "/Applications/ghostex.app/Contents/Resources/AppIcon.icns",
+      "name" : "Ghostex"
     }
   ],
   "focusDown" : "ctrl+opt+shift+down",

--- a/config/.config/herdr/config.toml
+++ b/config/.config/herdr/config.toml
@@ -1,0 +1,8 @@
+onboarding = false
+
+[ui]
+status_indicators = "symbols"
+
+show_agent_labels_on_pane_borders = true
+[ui.toast]
+delivery = "terminal"

--- a/config/.config/kitty/tab_bar.py
+++ b/config/.config/kitty/tab_bar.py
@@ -22,6 +22,9 @@ from kitty.boss import get_boss
 _CLR_BG = "#171928"  # background
 _CLR_TAB_BG = "#212337"  # inactive tab bg
 _CLR_CYAN = "#04D1F9"  # process segment
+_CLR_ORANGE = "#F7C67F"  # claude
+_CLR_BLUE = "#9071F4"  # pi
+_CLR_PINK = "#F265B5"  # omp
 _CLR_MUTED = "#7081D0"  # separators / dim text
 
 
@@ -38,6 +41,9 @@ def _color(hex_color: str) -> int:
 CLR_BG = _color(_CLR_BG)
 CLR_TAB_BG = _color(_CLR_TAB_BG)
 CLR_CYAN = _color(_CLR_CYAN)
+CLR_ORANGE = _color(_CLR_ORANGE)
+CLR_BLUE = _color(_CLR_BLUE)
+CLR_PINK = _color(_CLR_PINK)
 CLR_MUTED = _color(_CLR_MUTED)
 
 # ---------------------------------------------------------------------------
@@ -61,8 +67,22 @@ PROCESS_ICONS: dict[str, str] = {
     "make": "\U000f0218",  # md_cogs
     "lazygit": "\ue725",  # dev_git
     "yazi": "\U000f024b",  # md_folder
+    "claude": "\uec82",
+    "codex": "\uec81",
+    "pi": "\ue22c",
+    "omp": "\U000f03ff",
+    "jcode": "\U000f0af7",
+    "grok": "\U000f06a9",
+    "opencode": "\U000f06a9",
+    "prime-agent": "\U000f06a9",
+    "herdr": "\U000f06a9",
 }
 DEFAULT_ICON = "\uf489"  # fa_terminal fallback
+PROCESS_COLORS: dict[str, int] = {
+    "claude": CLR_ORANGE,
+    "pi": CLR_BLUE,
+    "omp": CLR_PINK,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -96,7 +116,7 @@ def _draw_status_area(screen: Screen) -> None:
     screen.cursor.bg = CLR_BG
     screen.cursor.fg = CLR_MUTED
     screen.draw(" " * (target_x - screen.cursor.x))
-    screen.cursor.fg = CLR_CYAN
+    screen.cursor.fg = PROCESS_COLORS.get(proc_name, CLR_CYAN)
     screen.draw(text)
 
 

--- a/config/.config/leaderkey/config.json
+++ b/config/.config/leaderkey/config.json
@@ -101,13 +101,13 @@
         },
         {
           "iconPath" : "/Applications/Cursor.app",
-          "key" : "r",
+          "key" : "c",
           "label" : "Cursor",
           "type" : "application",
           "value" : "/Applications/Cursor.app"
         },
         {
-          "key" : "c",
+          "key" : "C",
           "label" : "Claude Desktop",
           "type" : "application",
           "value" : "/Applications/Claude.app"

--- a/config/.config/topgrade.toml
+++ b/config/.config/topgrade.toml
@@ -49,16 +49,16 @@ autoremove = true
 [git]
 repos = [
   "/Users/ed/Developer/TUIApps/herdr/",
-  "/Users/ed/Developer/AI/Extensions/LifeOS/",
-  "/Users/ed/Developer/AI/Harness/Boop/",
+  "/Users/ed/Developer/AI/LifeOS/",
   "/Users/ed/Developer/AI/Harness/Neo/",
+  "/Users/ed/Developer/AI/Agents/Boop/",
   "/Users/ed/Developer/AI/Agents/Push/",
   "/Users/ed/Developer/AI/Skills/claude-cybersecurity/",
   "/Users/ed/Developer/AI/Skills/claude-seo/",
   "/Users/ed/Developer/AI/Skills/claude-obsidian/",
-  "/Users/ed/Developer/AI/Skills/skillsMattPocock/",
-  "/Users/ed/Developer/AI/Skills/skillsCompoundEngineering/",
-  "/Users/ed/Developer/AI/Skills/skillsBeagle/",
-  "/Users/ed/Developer/AI/Skills/dox-framework/",
-  "/Users/ed/Developer/AI/Skills/skillsBlueprint/",
+  "/Users/ed/Developer/AI/Skills/MattPocock/",
+  "/Users/ed/Developer/AI/Skills/CompoundEngineering/",
+  "/Users/ed/Developer/AI/Skills/Beagle/",
+  "/Users/ed/Developer/AI/Skills/DoxFramework/",
+  "/Users/ed/Developer/AI/Skills/Blueprint/",
 ]

--- a/fish/.config/fish/agent-harnesses.txt
+++ b/fish/.config/fish/agent-harnesses.txt
@@ -14,14 +14,14 @@
 #
 # Lines starting with # and blank lines are ignored.
 #
+#Opencode      | 61747f | opencode    | opencode | upgrade
 #
 
 
-Claude Code   | ff8c42 | claude      | claude | update
-Pi extensions | ff69b4 | pi          | -      | update --all
-OMP           | af87ff | omp         | omp    | update --force
-OMP plugins   | af87ff | omp         | omp    | plugins upgrade
-J code        | 5fff87 | jcode       | jcode  | update
-Prime-agent   | 61747f | prime-agent | -      | update --force
-Opencode      | 61747f | opencode | opencode | upgrade
-Herdr         | 5fd7ff | herdr       | herdr  | update
+OMP           | af87ff | omp         | omp         | update --force
+OMP plugins   | af87ff | omp         | omp         | plugins upgrade
+Pi+extensions | ff69b4 | pi          | -           | update --all
+Jcode         | 5fff87 | jcode       | jcode       | update
+Prime-agent   | 61747f | prime-agent | prime-agent | update --force
+Herdr         | 5fd7ff | herdr       | herdr       | update
+Claude Code   | ff8c42 | claude      | claude      | update

--- a/fish/.config/fish/agent-harnesses.txt
+++ b/fish/.config/fish/agent-harnesses.txt
@@ -18,10 +18,10 @@
 #
 
 
-OMP           | af87ff | omp         | omp         | update --force
-OMP plugins   | af87ff | omp         | omp         | plugins upgrade
+Herdr         | 5fd7ff | herdr       | herdr       | update
 Pi+extensions | ff69b4 | pi          | -           | update --all
 Jcode         | 5fff87 | jcode       | jcode       | update
 Prime-agent   | 61747f | prime-agent | prime-agent | update --force
-Herdr         | 5fd7ff | herdr       | herdr       | update
 Claude Code   | ff8c42 | claude      | claude      | update
+OMP plugins   | af87ff | omp         | omp         | update --plugins
+OMP           | af87ff | omp         | omp         | update --force


### PR DESCRIPTION
1. adds flashspace profiles, agent harnesses and kitty tabs updated (616aed1)
    - M config/.config/flashspace/profiles.json
    - M config/.config/kitty/tab_bar.py
    - M fish/.config/fish/agent-harnesses.txt
2. chore: add Ghostex, Herdr UI config, and Leader Key remaps (1355aa2)
    - A config/.config/herdr/config.toml
    - M config/.config/flashspace/profiles.json
    - M config/.config/flashspace/settings.json
    - M config/.config/leaderkey/config.json
3. tograde config update - changes to git_repos (f750fb2)
    - M config/.config/topgrade.toml
4. stacking commit (0234501)
5. chore(fish): reorder aup harness list and report prime-agent version (b0c2474)
    - M fish/.config/fish/agent-harnesses.txt